### PR TITLE
#16: Fix service mesh to show topology

### DIFF
--- a/kube/gateway/cfg/structs.go
+++ b/kube/gateway/cfg/structs.go
@@ -6,26 +6,24 @@ type Config struct {
 		Port int
 	}
 
-	Gen struct {
-		Word struct {
-			Service struct {
-				Host string
-				Port int
-			}
+	Word struct {
+		Service struct {
+			Host string
+			Port int
 		}
+	}
 
-		Number struct {
-			Service struct {
-				Host string
-				Port int
-			}
+	Number struct {
+		Service struct {
+			Host string
+			Port int
 		}
+	}
 
-		Internets struct {
-			Service struct {
-				Host string
-				Port int
-			}
+	Internets struct {
+		Service struct {
+			Host string
+			Port int
 		}
 	}
 }

--- a/kube/gateway/config.yaml
+++ b/kube/gateway/config.yaml
@@ -1,9 +1,9 @@
 own.port: 8000
 
 # Var names are chosen such that services addresses would be injected by kube
-gen.word.service.host: ~
-gen.word.service.port: ~
-gen.number.service.host: ~
-gen.number.service.port: ~
-gen.internets.service.host: ~
-gen.internets.service.port: ~
+word.service.host: word.gen
+word.service.port: 10000
+number.service.host: number.gen
+number.service.port: 10000
+internets.service.host: internets.gen
+internets.service.port: 10000

--- a/kube/gateway/kube.yaml
+++ b/kube/gateway/kube.yaml
@@ -1,39 +1,39 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: gen-gateway
+  name: gateway
   namespace: gen
   labels:
-    app: gen-gateway
+    app: gateway
 spec:
-  type: NodePort
+  type: LoadBalancer
   ports:
-    - port: 8000
+    - port: 80
       targetPort: 8000
-      protocol: TCP
-      name: gen-gateway
+      name: http
   selector:
-    app: gen-gateway
+    app: gateway
 ---
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: gen-gateway
+  name: gateway
   namespace: gen
   labels:
-    app: gen-gateway
+    app: gateway
 spec:
   replicas: 1
   selector:
     matchLabels:
-      app: gen-gateway
+      app: gateway
   template:
     metadata:
       labels:
-        app: gen-gateway
+        app: gateway
     spec:
       containers:
-      - name: gen-gateway
-        image: gcr.io/word-gen-314/gen-gateway
+      - name: gateway
+        image: gcr.io/word-gen-314/gateway
         ports:
-        - containerPort: 50051
+        - containerPort: 8000
+          name: http

--- a/kube/gateway/rpc/internets.go
+++ b/kube/gateway/rpc/internets.go
@@ -12,7 +12,7 @@ import (
 
 // GetWord requests word from internets
 func GetWord() (string, error) {
-	address := fmt.Sprintf("%s:%v", cfg.Conf.Gen.Internets.Service.Host, cfg.Conf.Gen.Internets.Service.Port)
+	address := fmt.Sprintf("%s:%v", cfg.Conf.Internets.Service.Host, cfg.Conf.Internets.Service.Port)
 	conn, err := grpc.Dial(address, grpc.WithInsecure())
 	if err != nil {
 		return "", fmt.Errorf("error while connecting: %v", err)

--- a/kube/gateway/rpc/number.go
+++ b/kube/gateway/rpc/number.go
@@ -12,7 +12,7 @@ import (
 
 // GenerateNumber requests number
 func GenerateNumber() (string, error) {
-	address := fmt.Sprintf("%s:%v", cfg.Conf.Gen.Number.Service.Host, cfg.Conf.Gen.Number.Service.Port)
+	address := fmt.Sprintf("%s:%v", cfg.Conf.Number.Service.Host, cfg.Conf.Number.Service.Port)
 	conn, err := grpc.Dial(address, grpc.WithInsecure())
 	if err != nil {
 		return "", fmt.Errorf("error while connecting: %v", err)

--- a/kube/gateway/rpc/word.go
+++ b/kube/gateway/rpc/word.go
@@ -12,7 +12,7 @@ import (
 
 // GenerateWord requests word from word generator
 func GenerateWord() (string, error) {
-	address := fmt.Sprintf("%s:%v", cfg.Conf.Gen.Word.Service.Host, cfg.Conf.Gen.Word.Service.Port)
+	address := fmt.Sprintf("%s:%v", cfg.Conf.Word.Service.Host, cfg.Conf.Word.Service.Port)
 	conn, err := grpc.Dial(address, grpc.WithInsecure())
 	if err != nil {
 		return "", fmt.Errorf("error while connecting: %v", err)

--- a/kube/internets/kube.yaml
+++ b/kube/internets/kube.yaml
@@ -1,36 +1,38 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: gen-internets
+  name: internets
   namespace: gen
   labels:
-    app: gen-internets
+    app: internets
 spec:
+  clusterIP: None
   ports:
     - port: 10000
-      name: gen-internets
+      name: grpc
   selector:
-    app: gen-internets
+    app: internets
 ---
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: gen-internets
+  name: internets
   namespace: gen
   labels:
-    app: gen-internets
+    app: internets
 spec:
   replicas: 1
   selector:
     matchLabels:
-      app: gen-internets
+      app: internets
   template:
     metadata:
       labels:
-        app: gen-internets
+        app: internets
     spec:
       containers:
-      - name: gen-internets
-        image: gcr.io/word-gen-314/gen-internets
+      - name: internets
+        image: gcr.io/word-gen-314/internets
         ports:
         - containerPort: 10000
+          name: grpc

--- a/kube/number/kube.yaml
+++ b/kube/number/kube.yaml
@@ -1,36 +1,38 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: gen-number
+  name: number
   namespace: gen
   labels:
-    app: gen-number
+    app: number
 spec:
+  clusterIP: None
   ports:
     - port: 10000
-      name: gen-number
+      name: grpc
   selector:
-    app: gen-number
+    app: number
 ---
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: gen-number
+  name: number
   namespace: gen
   labels:
-    app: gen-number
+    app: number
 spec:
   replicas: 1
   selector:
     matchLabels:
-      app: gen-number
+      app: number
   template:
     metadata:
       labels:
-        app: gen-number
+        app: number
     spec:
       containers:
-      - name: gen-number
-        image: gcr.io/word-gen-314/gen-number
+      - name: number
+        image: gcr.io/word-gen-314/number
         ports:
         - containerPort: 10000
+          name: grpc

--- a/kube/skaffold.yaml
+++ b/kube/skaffold.yaml
@@ -2,20 +2,20 @@ apiVersion: skaffold/v1beta5
 kind: Config
 build:
   artifacts:
-  - image: gcr.io/word-gen-314/gen-gateway
+  - image: gcr.io/word-gen-314/gateway
     context: gateway
-  - image: gcr.io/word-gen-314/gen-internets
+  - image: gcr.io/word-gen-314/internets
     context: internets
-  - image: gcr.io/word-gen-314/gen-number
+  - image: gcr.io/word-gen-314/number
     context: number
-  - image: gcr.io/word-gen-314/gen-word
+  - image: gcr.io/word-gen-314/word
     context: word
-  - image: gcr.io/word-gen-314/gen-testtools
+  - image: gcr.io/word-gen-314/testtools
     context: testtools
 deploy:
   kubectl:
     manifests:
-    - kube.yaml
+    # - kube.yaml
     - gateway/kube.yaml
     - internets/kube.yaml
     - number/kube.yaml

--- a/kube/testtools/cfg/structs.go
+++ b/kube/testtools/cfg/structs.go
@@ -6,12 +6,9 @@ type Config struct {
 		RPS int
 	}
 
-	Gen struct {
-		Gateway struct {
-			Service struct {
-				Host string
-				Port string
-			}
+	Gateway struct {
+		Service struct {
+			Address string
 		}
 	}
 }

--- a/kube/testtools/config.yaml
+++ b/kube/testtools/config.yaml
@@ -1,6 +1,4 @@
 default:
   rps: 10
 
-# Names are chosen such that GEN_GATEWAY_SERVICE_HOST var provided by kubernetes would override it
-gen.gateway.service.host: 192.168.99.100
-gen.gateway.service.port: 30515
+gateway.service.address: http://gateway.gen

--- a/kube/testtools/kube.yaml
+++ b/kube/testtools/kube.yaml
@@ -17,4 +17,4 @@ spec:
     spec:
       containers:
       - name: load-generator
-        image: gcr.io/word-gen-314/gen-testtools
+        image: gcr.io/word-gen-314/testtools

--- a/kube/testtools/load/generator.go
+++ b/kube/testtools/load/generator.go
@@ -45,7 +45,7 @@ func makeRequest() {
 			fmt.Println("Recovered from panic", r)
 		}
 	}()
-	address := fmt.Sprintf("http://%s:%s", cfg.Conf.Gen.Gateway.Service.Host, cfg.Conf.Gen.Gateway.Service.Port)
+	address := cfg.Conf.Gateway.Service.Address
 	resp, err := http.Get(address)
 	if err != nil {
 		log.Printf("error while making request: %v", err)

--- a/kube/word/kube.yaml
+++ b/kube/word/kube.yaml
@@ -1,36 +1,38 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: gen-word
+  name: word
   namespace: gen
   labels:
-    app: gen-word
+    app: word
 spec:
+  clusterIP: None
   ports:
     - port: 10000
-      name: gen-word
+      name: grpc
   selector:
-    app: gen-word
+    app: word
 ---
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: gen-word
+  name: word
   namespace: gen
   labels:
-    app: gen-word
+    app: word
 spec:
   replicas: 1
   selector:
     matchLabels:
-      app: gen-word
+      app: word
   template:
     metadata:
       labels:
-        app: gen-word
+        app: word
     spec:
       containers:
-      - name: gen-word
-        image: gcr.io/word-gen-314/gen-word
+      - name: word
+        image: gcr.io/word-gen-314/word
         ports:
         - containerPort: 10000
+          name: grpc


### PR DESCRIPTION
<img width="1525" alt="screen shot 2019-03-01 at 1 36 35 am" src="https://user-images.githubusercontent.com/550350/53629484-83a78980-3bc2-11e9-81e5-5646eb4e9068.png">

Looks like to have service topology few things are required:
 * Services should be discovered by DNS name, not by using `*_SERVICE_HOST` and `*_SERVICE_PORT` env vars.
 * grpc services must have `ClusterIP: None`
 * web service must expose port 80: Proxy was failing with message 
```
[gateway-64778f78bf-6m47t linkerd-proxy] ERR! proxy={server=in listen=0.0.0.0:4143 remote=10.36.0.115:49580} linkerd2_proxy::proxy::http::router service error: an error occurred trying to connect: Connection refused (os error 111) (address: 127.0.0.1:80)
``` 
before I changed port to `80`